### PR TITLE
Add intent to email chat history

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ response.
 
 To send a single query to an LLM, you can ask Neon to "ask Chat GPT <something>".
 To start conversing with an LLM, ask to "talk to Chat GPT" and have all of your input
-sent to an LLM until you say goodbye or stop talking for awhile.
+sent to an LLM until you say goodbye or stop talking for a while.
 
 Enable fallback behavior by asking to "enable LLM fallback skill" or disable it
 by asking to "disable LLM fallback".
+
+To have a copy of LLM interactions sent via email, ask Neon to 
+"email me a copy of our conversation".
 
 ## Examples 
 
@@ -21,3 +24,4 @@ by asking to "disable LLM fallback".
 * "Talk to chat GPT"
 * "Enable LLM fallback skill"
 * "Disable LLM fallback skill"
+* "Email me a copy of our conversation"

--- a/__init__.py
+++ b/__init__.py
@@ -156,6 +156,8 @@ class LLMSkill(NeonFallbackSkill):
         self.gui.remove_controlled_notification()
         self.chatting.pop(user)
         self.speak_dialog("end_chat")
+        event_name = f"end_converse.{user}"
+        self.cancel_scheduled_event(event_name)
 
     def _get_llm_response(self, query: str, user: str) -> str:
         """
@@ -185,7 +187,8 @@ class LLMSkill(NeonFallbackSkill):
             LOG.info(f"Chat session timed out")
             self._stop_chatting(message)
             return False
-        utterance = message.data.get('utterances', [])[0]
+        # Take final utterance as one that wasn't normalized
+        utterance = message.data.get('utterances', [""])[-1]
         if self.voc_match(utterance, "exit"):
             self._stop_chatting(message)
             return True

--- a/__init__.py
+++ b/__init__.py
@@ -147,7 +147,8 @@ class LLMSkill(NeonFallbackSkill):
         history = self.chat_history.get(username)
         email_text = ""
         for entry in history:
-            email_text += f"[{entry[0]}] {entry[1]}\n"
+            formatted = entry[1].replace('\n', '\n\t')
+            email_text += f"[{entry[0]}] {formatted}\n"
         NeonSkill.send_email(self, "LLM Conversation", email_text,
                              email_addr=email)
 

--- a/__init__.py
+++ b/__init__.py
@@ -173,7 +173,8 @@ class LLMSkill(NeonFallbackSkill):
                                   "chat_gpt_input")
         resp = mq_resp.get("response") or ""
         if resp:
-            self.chat_history[user].append(("user", query))
+            username = "user" if user == self._default_user else user
+            self.chat_history[user].append((username, query))
             self.chat_history[user].append(("llm", resp))
         LOG.debug(f"Got LLM response: {resp}")
         return resp

--- a/__init__.py
+++ b/__init__.py
@@ -147,7 +147,7 @@ class LLMSkill(NeonFallbackSkill):
         history = self.chat_history.get(username)
         email_text = ""
         for entry in history:
-            email_text += f"{entry[0].rjust(8, ' ')} - {entry[1]}"
+            email_text += f"[{entry[0].rjust(8, ' ')}] - {entry[1]}\n"
         NeonSkill.send_email(self, "LLM Conversation", email_text,
                              email_addr=email)
 

--- a/__init__.py
+++ b/__init__.py
@@ -33,7 +33,7 @@ from ovos_utils import classproperty
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import RuntimeRequirements
 # from ovos_workshop.skills.fallback import FallbackSkill
-from neon_utils.skills.neon_fallback_skill import NeonFallbackSkill
+from neon_utils.skills.neon_fallback_skill import NeonFallbackSkill, NeonSkill
 from neon_utils.message_utils import get_message_user
 from neon_utils.user_utils import get_user_prefs
 from neon_mq_connector.utils.client_utils import send_mq_request
@@ -148,7 +148,8 @@ class LLMSkill(NeonFallbackSkill):
         email_text = ""
         for entry in history:
             email_text += f"{entry[0].rjust(8, ' ')} - {entry[1]}"
-        self.send_email("LLM Conversation", email_text, email_addr=email)
+        NeonSkill.send_email(self, "LLM Conversation", email_text,
+                             email_addr=email)
 
     def _stop_chatting(self, message):
         user = get_message_user(message) or self._default_user

--- a/__init__.py
+++ b/__init__.py
@@ -147,7 +147,7 @@ class LLMSkill(NeonFallbackSkill):
         history = self.chat_history.get(username)
         email_text = ""
         for entry in history:
-            formatted = entry[1].replace('\n', '\n\t')
+            formatted = entry[1].replace('\n\n', '\n\t...')
             email_text += f"[{entry[0]}] {formatted}\n"
         NeonSkill.send_email(self, "LLM Conversation", email_text,
                              email_addr=email)

--- a/__init__.py
+++ b/__init__.py
@@ -147,7 +147,7 @@ class LLMSkill(NeonFallbackSkill):
         history = self.chat_history.get(username)
         email_text = ""
         for entry in history:
-            email_text += f"[{entry[0].rjust(8, ' ')}] - {entry[1]}\n"
+            email_text += f"[{entry[0]}] {entry[1]}\n"
         NeonSkill.send_email(self, "LLM Conversation", email_text,
                              email_addr=email)
 

--- a/__init__.py
+++ b/__init__.py
@@ -147,7 +147,7 @@ class LLMSkill(NeonFallbackSkill):
         history = self.chat_history.get(username)
         email_text = ""
         for entry in history:
-            formatted = entry[1].replace('\n\n', '\n\t...')
+            formatted = entry[1].replace('\n\n', '\n').replace('\n', '\n\t...')
             email_text += f"[{entry[0]}] {formatted}\n"
         NeonSkill.send_email(self, "LLM Conversation", email_text,
                              email_addr=email)

--- a/locale/en-us/dialog/no_chat_history.dialog
+++ b/locale/en-us/dialog/no_chat_history.dialog
@@ -1,0 +1,1 @@
+I don't have any chat history to send you.

--- a/locale/en-us/dialog/no_email_address.dialog
+++ b/locale/en-us/dialog/no_email_address.dialog
@@ -1,0 +1,1 @@
+Sorry, please tell me your email address and try again.

--- a/locale/en-us/dialog/sending_chat_history.dialog
+++ b/locale/en-us/dialog/sending_chat_history.dialog
@@ -1,0 +1,1 @@
+Okay, I will send a transcript of our conversation to you at {{email}}.

--- a/locale/en-us/intent/email_chat_history.intent
+++ b/locale/en-us/intent/email_chat_history.intent
@@ -1,1 +1,2 @@
 (send|email) me (a copy of |a transcript of |)(the|my|your|our|that) (chat|conversation)( history|)
+send me our conversation

--- a/locale/en-us/intent/email_chat_history.intent
+++ b/locale/en-us/intent/email_chat_history.intent
@@ -1,1 +1,1 @@
-(send|email) me (the|my|your|our) (chat|conversation)( history|)
+(send|email) me (a copy of |)(the|my|your|our) (chat|conversation)( history|)

--- a/locale/en-us/intent/email_chat_history.intent
+++ b/locale/en-us/intent/email_chat_history.intent
@@ -1,1 +1,1 @@
-(send|email) me (a copy of |)(the|my|your|our) (chat|conversation)( history|)
+(send|email) me (a copy of |a transcript of|)(the|my|your|our|that) (chat|conversation)( history|)

--- a/locale/en-us/intent/email_chat_history.intent
+++ b/locale/en-us/intent/email_chat_history.intent
@@ -1,1 +1,1 @@
-(send|email) me (a copy of |a transcript of|)(the|my|your|our|that) (chat|conversation)( history|)
+(send|email) me (a copy of |a transcript of |)(the|my|your|our|that) (chat|conversation)( history|)

--- a/locale/en-us/intent/email_chat_history.intent
+++ b/locale/en-us/intent/email_chat_history.intent
@@ -1,0 +1,1 @@
+(send|email) me (the|my|your|our) (chat|conversation)( history|)

--- a/skill.json
+++ b/skill.json
@@ -3,13 +3,14 @@
     "url": "https://github.com/NeonGeckoCom/skill-fallback_llm",
     "summary": "Get an LLM response from the Neon Diana backend.",
     "short_description": "Get an LLM response from the Neon Diana backend.",
-    "description": "Converse with an LLM and enable LLM responses when Neon doesn't have a better response. To send a single query to an LLM, you can ask Neon to \"ask Chat GPT <something>\". To start conversing with an LLM, ask to \"talk to Chat GPT\" and have all of your input sent to an LLM until you say goodbye or stop talking for awhile. Enable fallback behavior by asking to \"enable LLM fallback skill\" or disable it by asking to \"disable LLM fallback\".",
+    "description": "Converse with an LLM and enable LLM responses when Neon doesn't have a better response. To send a single query to an LLM, you can ask Neon to \"ask Chat GPT <something>\". To start conversing with an LLM, ask to \"talk to Chat GPT\" and have all of your input sent to an LLM until you say goodbye or stop talking for a while. Enable fallback behavior by asking to \"enable LLM fallback skill\" or disable it by asking to \"disable LLM fallback\". To have a copy of LLM interactions sent via email, ask Neon to \"email me a copy of our conversation\".",
     "examples": [
         "Explain quantum computing in simple terms",
         "Ask chat GPT what an LLM is",
         "Talk to chat GPT",
         "Enable LLM fallback skill",
-        "Disable LLM fallback skill"
+        "Disable LLM fallback skill",
+        "Email me a copy of our conversation"
     ],
     "desktopFile": false,
     "warning": "",

--- a/test/test_intents.yaml
+++ b/test/test_intents.yaml
@@ -44,7 +44,8 @@ en-us:
     - disable chat g p t fallback skill
   enable_chat_history.intent:
     - send me our conversation
-    - email my your chat history
+    - email me your chat history
+    - email me a copy of our conversation
 
 unmatched intents:
   en-us:

--- a/test/test_intents.yaml
+++ b/test/test_intents.yaml
@@ -42,7 +42,7 @@ en-us:
     - enable chat gpt fallback
   disable_fallback.intent:
     - disable chat g p t fallback skill
-  enable_chat_history.intent:
+  email_chat_history.intent:
     - send me our conversation
     - email me your chat history
     - email me a copy of our conversation

--- a/test/test_intents.yaml
+++ b/test/test_intents.yaml
@@ -46,6 +46,7 @@ en-us:
     - send me our conversation
     - email me your chat history
     - email me a copy of our conversation
+    - send me a transcript of our chat
 
 unmatched intents:
   en-us:
@@ -53,3 +54,5 @@ unmatched intents:
     - tell me about rocks
     - enable wake words
     - disable listening confirmation
+    - send me an email
+    - email me a support ticket

--- a/test/test_intents.yaml
+++ b/test/test_intents.yaml
@@ -42,6 +42,9 @@ en-us:
     - enable chat gpt fallback
   disable_fallback.intent:
     - disable chat g p t fallback skill
+  enable_chat_history.intent:
+    - send me our conversation
+    - email my your chat history
 
 unmatched intents:
   en-us:

--- a/test/test_resources.yaml
+++ b/test/test_resources.yaml
@@ -14,6 +14,9 @@ dialog:
   - no_chatgpt
   - start_chat
   - notify_llm_active
+  - no_chat_history
+  - no_email_address
+  - sending_chat_history
 regex: []
 intents:
   # Padatious intents are the `.intent` file names
@@ -22,4 +25,5 @@ intents:
     - chat_with_llm.intent
     - disable_fallback.intent
     - enable_fallback.intent
+    - email_chat_history.intent
   adapt: []

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -108,9 +108,59 @@ class TestSkill(unittest.TestCase):
         self.skill.handle_chat_with_llm(fake_msg)
         self.assertIsInstance(self.skill.chatting["test_user"], float)
 
+    def test_handle_email_chat_history(self):
+        real_send_email = self.skill._send_email
+        self.skill._send_email = Mock()
+
+        from neon_utils.user_utils import get_default_user_config
+        default_profile = get_default_user_config()
+        default_profile['user']['username'] = 'test_user'
+        default_profile['user']['email'] = ''
+        test_message = Message("", {}, {"username": "test_user",
+                                        "user_profiles": [default_profile]})
+        # No Chat History
+        self.skill.handle_email_chat_history(test_message)
+        self.skill.speak_dialog.assert_called_once_with("no_chat_history",
+                                                        private=True)
+
+        # No Email Address
+        self.skill.chat_history['test_user'] = [("user", "hey"), ("llm", "hi")]
+        self.skill.handle_email_chat_history(test_message)
+        self.skill.speak_dialog.assert_called_with("no_email_address",
+                                                   private=True)
+
+        # Valid Request
+        test_message.context['user_profiles'][0]['user']['email'] = \
+            "test@neon.ai"
+        self.skill.handle_email_chat_history(test_message)
+        self.skill.speak_dialog.assert_called_with("sending_chat_history",
+                                                   {"email": "test@neon.ai"},
+                                                   private=True)
+        self.skill._send_email.assert_called_once_with("test_user",
+                                                       "test@neon.ai")
+
+        self.skill._send_email = real_send_email
+
     def test_converse(self):
         # TODO
         pass
+
+    def test_threaded_converse(self):
+        # TODO
+        pass
+
+    def test_reset_expiration(self):
+        # TODO
+        pass
+
+    def test_stop_chatting(self):
+        # TODO
+        pass
+
+    def test_send_email(self):
+        # TODO
+        pass
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Description
Adds an intent to send an email transcript of a conversation with ChatGPT
Stub out future unit tests
Suppress logged errors after a user ends chatting

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->