### PR TITLE
Support Fast Chat endpoint

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -206,7 +206,7 @@ class LLMSkill(NeonFallbackSkill):
         user = get_message_user(message) or self._default_user
         if user not in self.chatting:
             return False
-        last_message = self.chatting[user]
+        last_message = self.chatting[user][0]
         if time() - last_message > self.chat_timeout_seconds:
             LOG.info(f"Chat session timed out")
             self._stop_chatting(message)

--- a/__init__.py
+++ b/__init__.py
@@ -30,6 +30,7 @@ from threading import Thread
 from time import time
 
 from lingua_franca.format import nice_duration
+from ovos_bus_client import Message
 from ovos_utils import classproperty
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import RuntimeRequirements
@@ -44,6 +45,7 @@ from mycroft.skills.mycroft_skill.decorators import intent_handler
 
 class LLM(Enum):
     GPT = "Chat GPT"
+    FASTCHAT = "FastChat"
 
 
 class LLMSkill(NeonFallbackSkill):
@@ -51,6 +53,7 @@ class LLMSkill(NeonFallbackSkill):
         NeonFallbackSkill.__init__(self, **kwargs)
         self.chat_history = dict()
         self._default_user = "local"
+        self._default_llm = LLM.FASTCHAT
         self.chatting = dict()
 
     @classproperty
@@ -83,7 +86,7 @@ class LLMSkill(NeonFallbackSkill):
     def fallback_llm(self, message):
         utterance = message.data['utterance']
         user = get_message_user(message) or self._default_user
-        answer = self._get_llm_response(utterance, user)
+        answer = self._get_llm_response(utterance, user, self._default_llm)
         if not answer:
             LOG.info(f"No fallback response")
             return False
@@ -104,12 +107,13 @@ class LLMSkill(NeonFallbackSkill):
             self.remove_fallback(self.fallback_llm)
         self.speak_dialog("fallback_disabled")
 
-    @intent_handler("ask_chatgpt.intent")
+    @intent_handler("ask_llm.intent")
     def handle_ask_chatgpt(self, message):
         utterance = message.data['utterance']
+        llm = self._get_requested_llm(message)
         user = get_message_user(message) or self._default_user
         try:
-            resp = self._get_llm_response(utterance, user)
+            resp = self._get_llm_response(utterance, user, llm)
             self.speak(resp)
         except Exception as e:
             LOG.exception(e)
@@ -120,17 +124,12 @@ class LLMSkill(NeonFallbackSkill):
         user = get_message_user(message) or self._default_user
         self.gui.show_controlled_notification(
             self.translate("notify_llm_active"))
-        llm = message.data.get('llm')
-        if self.voc_match(llm, "chat_gpt"):
-            llm = LLM.GPT
-        else:
-            LOG.warning(f"Requested invalid LLM: {llm}")
-            llm = LLM.GPT
+        llm = self._get_requested_llm(message)
         timeout_duration = nice_duration(self.chat_timeout_seconds)
         self.speak_dialog("start_chat", {"llm": llm.value,
                                          "timeout": timeout_duration},
                           private=True)
-        self._reset_expiration(user)
+        self._reset_expiration(user, llm)
 
     @intent_handler("email_chat_history.intent")
     def handle_email_chat_history(self, message):
@@ -167,18 +166,23 @@ class LLMSkill(NeonFallbackSkill):
         event_name = f"end_converse.{user}"
         self.cancel_scheduled_event(event_name)
 
-    def _get_llm_response(self, query: str, user: str) -> str:
+    def _get_llm_response(self, query: str, user: str, llm: LLM) -> str:
         """
         Get a response from an LLM
         :param query: User utterance to generate a response to
         :param user: Username making the request
         :returns: Speakable response to the user's query
         """
-        # TODO: support multiple LLM backends?
+        if llm == LLM.GPT:
+            queue = "chat_gpt_input"
+        elif llm == LLM.FASTCHAT:
+            queue = "fastchat_input"
+        else:
+            raise ValueError(f"Expected LLM, got: {llm}")
         self.chat_history.setdefault(user, list())
         mq_resp = send_mq_request("/llm", {"query": query,
                                            "history": self.chat_history[user]},
-                                  "chat_gpt_input")
+                                  queue)
         resp = mq_resp.get("response") or ""
         if resp:
             username = "user" if user == self._default_user else user
@@ -186,6 +190,17 @@ class LLMSkill(NeonFallbackSkill):
             self.chat_history[user].append(("llm", resp))
         LOG.debug(f"Got LLM response: {resp}")
         return resp
+
+    def _get_requested_llm(self, message: Message) -> LLM:
+        request = message.data.get('llm') or message.data.get('utterance')
+        if self.voc_match(request, "chat_gpt"):
+            llm = LLM.GPT
+        elif self.voc_match(request, "fastchat"):
+            llm = LLM.FASTCHAT
+        else:
+            LOG.warning(f"No valid LLM in request: {request}")
+            llm = LLM.GPT
+        return llm
 
     def converse(self, message=None):
         user = get_message_user(message) or self._default_user
@@ -207,15 +222,16 @@ class LLMSkill(NeonFallbackSkill):
 
     def _threaded_converse(self, utterance, user):
         try:
-            resp = self._get_llm_response(utterance, user)
+            llm = self.chatting[user][1]
+            resp = self._get_llm_response(utterance, user, llm)
             self.speak(resp)
-            self._reset_expiration(user)
+            self._reset_expiration(user, llm)
         except Exception as e:
             LOG.exception(e)
             self.speak_dialog("no_chatgpt")
 
-    def _reset_expiration(self, user):
-        self.chatting[user] = time()
+    def _reset_expiration(self, user, llm):
+        self.chatting[user] = (time(), llm)
         event_name = f"end_converse.{user}"
         self.cancel_scheduled_event(event_name)
         self.schedule_event(self._stop_chatting, self.chat_timeout_seconds,

--- a/__init__.py
+++ b/__init__.py
@@ -213,7 +213,8 @@ class LLMSkill(NeonFallbackSkill):
             return False
         # Take final utterance as one that wasn't normalized
         utterance = message.data.get('utterances', [""])[-1]
-        if self.voc_match(utterance, "exit"):
+        if self.voc_match(utterance, "exit") and len(utterance.split()) < 4:
+            # TODO: Imperfect check for "stop" or "exit"
             self._stop_chatting(message)
             return True
         Thread(target=self._threaded_converse, args=(utterance, user),

--- a/locale/en-us/intent/ask_chatgpt.intent
+++ b/locale/en-us/intent/ask_chatgpt.intent
@@ -1,1 +1,0 @@
-(ask|tell) (chatgpt|chat gpt|chat g p t|chat gpg|chat gptc) {question}

--- a/locale/en-us/intent/ask_llm.intent
+++ b/locale/en-us/intent/ask_llm.intent
@@ -1,0 +1,1 @@
+(ask|tell) (chatgpt|chat gpt|chat g p t|chat gpg|chat gptc|fast chat|fastchat) {question}

--- a/locale/en-us/intent/chat_with_llm.intent
+++ b/locale/en-us/intent/chat_with_llm.intent
@@ -1,1 +1,1 @@
-(i want to |)(chat|talk|converse|start a conversation) (to|with) (chat gpt|chat g p t|chat gpg|chatgpt)
+(i want to |)(chat|talk|converse|start a conversation) (to|with) (chat gpt|chat g p t|chat gpg|chatgpt|fastchat|fast chat)

--- a/locale/en-us/vocab/fastchat.voc
+++ b/locale/en-us/vocab/fastchat.voc
@@ -1,0 +1,2 @@
+fastchat
+fast chat

--- a/test/test_intents.yaml
+++ b/test/test_intents.yaml
@@ -22,7 +22,7 @@
 
 
 en-us:
-  ask_chatgpt.intent:
+  ask_llm.intent:
     - ask chat gpt what an umbrella is:
         - question: what an umbrella is
     - tell chatgpt my name is neon:

--- a/test/test_resources.yaml
+++ b/test/test_resources.yaml
@@ -8,6 +8,7 @@ languages:
 vocab:
   - exit
   - chat_gpt
+  - fastchat
 # dialog is .dialog file basenames (case-sensitive)
 dialog:
   - end_chat

--- a/test/test_resources.yaml
+++ b/test/test_resources.yaml
@@ -22,7 +22,7 @@ regex: []
 intents:
   # Padatious intents are the `.intent` file names
   padatious:
-    - ask_chatgpt.intent
+    - ask_llm.intent
     - chat_with_llm.intent
     - disable_fallback.intent
     - enable_fallback.intent

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -91,7 +91,13 @@ class TestSkill(unittest.TestCase):
         fake_msg = Message("test", {"utterance": "testing"},
                            {"username": "test_user"})
         self.skill.handle_ask_chatgpt(fake_msg)
-        mock.assert_called_once_with("testing", "test_user", LLM.GPT)
+        mock.assert_called_once()
+        args = mock.call_args
+        self.assertEqual(args[0], 'testing')
+        self.assertEqual(args[1], 'test_user')
+        self.assertEqual(args[2].value, LLM.GPT.value)
+        # TODO: Diagnose failure
+        # mock.assert_called_once_with("testing", "test_user", LLM.GPT)
         self.skill.speak.assert_called_once_with("test")
 
         def raise_exception():

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -112,7 +112,9 @@ class TestSkill(unittest.TestCase):
         self.skill.chatting = dict()
         self.skill.handle_chat_with_llm(fake_msg)
         self.assertIsInstance(self.skill.chatting["test_user"][0], float)
-        self.assertEqual(self.skill.chatting["test_user"][1], LLM.GPT)
+        # TODO: Diagnose equality failure
+        self.assertEqual(self.skill.chatting["test_user"][1].value,
+                         LLM.GPT.value)
         self.skill.speak_dialog.assert_called_once_with(
             "start_chat", {"llm": "Chat GPT", "timeout": "five minutes"},
             private=True)

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -92,7 +92,7 @@ class TestSkill(unittest.TestCase):
                            {"username": "test_user"})
         self.skill.handle_ask_chatgpt(fake_msg)
         mock.assert_called_once()
-        args = mock.call_args
+        args = mock.call_args[0]
         self.assertEqual(args[0], 'testing')
         self.assertEqual(args[1], 'test_user')
         self.assertEqual(args[2].value, LLM.GPT.value)

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -109,7 +109,8 @@ class TestSkill(unittest.TestCase):
                            {"username": "test_user"})
         self.skill.chatting = dict()
         self.skill.handle_chat_with_llm(fake_msg)
-        self.assertIsInstance(self.skill.chatting["test_user"], float)
+        self.assertIsInstance(self.skill.chatting["test_user"][0], float)
+        self.assertIsNotNone(self.skill.chatting["test_user"][1])
         self.skill.speak_dialog.assert_called_once_with(
             "start_chat", {"llm": "Chat GPT", "timeout": "five minutes"},
             private=True)

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -36,6 +36,8 @@ from ovos_bus_client import Message
 from lingua_franca import load_language
 from mycroft.skills.skill_loader import SkillLoader
 
+from skill_fallback_llm import LLM
+
 
 class TestSkill(unittest.TestCase):
     @classmethod
@@ -89,7 +91,7 @@ class TestSkill(unittest.TestCase):
         fake_msg = Message("test", {"utterance": "testing"},
                            {"username": "test_user"})
         self.skill.handle_ask_chatgpt(fake_msg)
-        mock.assert_called_once_with("testing", "test_user")
+        mock.assert_called_once_with("testing", "test_user", LLM.GPT)
         self.skill.speak.assert_called_once_with("test")
 
         def raise_exception():
@@ -110,7 +112,7 @@ class TestSkill(unittest.TestCase):
         self.skill.chatting = dict()
         self.skill.handle_chat_with_llm(fake_msg)
         self.assertIsInstance(self.skill.chatting["test_user"][0], float)
-        self.assertIsNotNone(self.skill.chatting["test_user"][1])
+        self.assertEqual(self.skill.chatting["test_user"][1], LLM.GPT)
         self.skill.speak_dialog.assert_called_once_with(
             "start_chat", {"llm": "Chat GPT", "timeout": "five minutes"},
             private=True)


### PR DESCRIPTION
# Description
Add `FastChat` LLM
Update skill to handle multiple LLM queues on the same MQ vhost
Minor refactoring to simplify logic and better handle converse

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->