### PR TITLE
Refactor for better compat. with OVOS dependencies

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -35,11 +35,10 @@ from ovos_utils import classproperty
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import RuntimeRequirements
 from ovos_workshop.skills.fallback import FallbackSkill
+from ovos_workshop.decorators import intent_handler
 from neon_utils.message_utils import get_message_user, dig_for_message
 from neon_utils.user_utils import get_user_prefs
 from neon_mq_connector.utils.client_utils import send_mq_request
-
-from mycroft.skills.mycroft_skill.decorators import intent_handler
 
 
 class LLM(Enum):

--- a/__init__.py
+++ b/__init__.py
@@ -34,7 +34,7 @@ from ovos_bus_client import Message
 from ovos_utils import classproperty
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import RuntimeRequirements
-from ovos_workshop.skills.fallback import FallbackSkill
+from ovos_workshop.skills.fallback import FallbackSkillV1 as FallbackSkill
 from ovos_workshop.decorators import intent_handler
 from neon_utils.message_utils import get_message_user, dig_for_message
 from neon_utils.user_utils import get_user_prefs

--- a/__init__.py
+++ b/__init__.py
@@ -34,9 +34,8 @@ from ovos_bus_client import Message
 from ovos_utils import classproperty
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import RuntimeRequirements
-# from ovos_workshop.skills.fallback import FallbackSkill
-from neon_utils.skills.neon_fallback_skill import NeonFallbackSkill, NeonSkill
-from neon_utils.message_utils import get_message_user
+from ovos_workshop.skills.fallback import FallbackSkill
+from neon_utils.message_utils import get_message_user, dig_for_message
 from neon_utils.user_utils import get_user_prefs
 from neon_mq_connector.utils.client_utils import send_mq_request
 
@@ -48,9 +47,9 @@ class LLM(Enum):
     FASTCHAT = "FastChat"
 
 
-class LLMSkill(NeonFallbackSkill):
+class LLMSkill(FallbackSkill):
     def __init__(self, **kwargs):
-        NeonFallbackSkill.__init__(self, **kwargs)
+        FallbackSkill.__init__(self, **kwargs)
         self.chat_history = dict()
         self._default_user = "local"
         self._default_llm = LLM.FASTCHAT
@@ -155,8 +154,7 @@ class LLMSkill(NeonFallbackSkill):
         for entry in history:
             formatted = entry[1].replace('\n\n', '\n').replace('\n', '\n\t...')
             email_text += f"[{entry[0]}] {formatted}\n"
-        NeonSkill.send_email(self, "LLM Conversation", email_text,
-                             email_addr=email)
+        self.send_email("LLM Conversation", email_text, email_addr=email)
 
     def _stop_chatting(self, message):
         user = get_message_user(message) or self._default_user
@@ -237,3 +235,38 @@ class LLMSkill(NeonFallbackSkill):
         self.cancel_scheduled_event(event_name)
         self.schedule_event(self._stop_chatting, self.chat_timeout_seconds,
                             {'user': user}, event_name)
+
+    # TODO: copied from NeonSkill. This method should be moved to a standalone
+    #       utility
+    def send_email(self, title, body, message=None, email_addr=None,
+                   attachments=None):
+        """
+        Send an email to the registered user's email.
+        Method here for backwards compatibility with Mycroft skills.
+        Email address priority: email_addr, user prefs from message,
+         fallback to DeviceApi for Mycroft method
+
+        Arguments:
+            title (str): Title of email
+            body  (str): HTML body of email. This supports
+                         simple HTML like bold and italics
+            email_addr (str): Optional email address to send message to
+            attachments (dict): Optional dict of file names to Base64 encoded files
+            message (Message): Optional message to get email from
+        """
+        message = message or dig_for_message()
+        if not email_addr and message:
+            email_addr = get_user_prefs(message)["user"].get("email")
+
+        if email_addr and send_mq_request:
+            LOG.info("Send email via Neon Server")
+            request_data = {"recipient": email_addr,
+                            "subject": title,
+                            "body": body,
+                            "attachments": attachments}
+            data = send_mq_request("/neon_emails", request_data,
+                                   "neon_emails_input")
+            return data.get("success")
+        else:
+            LOG.warning("Attempting to send email via Mycroft Backend")
+            super().send_email(title, body)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,1 @@
+neon-minerva[padatious]~=0.1,>=0.1.1a1

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
     url=f'https://github.com/NeonGeckoCom/{SKILL_NAME}',
     license='BSD-3-Clause',
     install_requires=get_requirements("requirements.txt"),
+    extras_require={"test": get_requirements("requirements/test.txt")},
     author='Neongecko',
     author_email='developers@neon.ai',
     long_description=long_description,

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -28,7 +28,7 @@
 
 import unittest
 
-from os import mkdir
+from os import mkdir, environ
 from os.path import dirname, join, exists
 from mock import Mock
 from ovos_utils.messagebus import FakeBus
@@ -40,6 +40,12 @@ from skill_fallback_llm import LLM
 
 
 class TestSkill(unittest.TestCase):
+    test_fs = join(dirname(__file__), "skill_fs")
+    data_dir = join(test_fs, "data")
+    conf_dir = join(test_fs, "config")
+    environ["XDG_DATA_HOME"] = data_dir
+    environ["XDG_CONFIG_HOME"] = conf_dir
+
     @classmethod
     def setUpClass(cls) -> None:
         bus = FakeBus()
@@ -49,15 +55,15 @@ class TestSkill(unittest.TestCase):
         cls.skill = skill_loader.instance
 
         # Define a directory to use for testing
-        cls.test_fs = join(dirname(__file__), "skill_fs")
-        if not exists(cls.test_fs):
-            mkdir(cls.test_fs)
+        # cls.test_fs = join(dirname(__file__), "skill_fs")
+        # if not exists(cls.test_fs):
+        #     mkdir(cls.test_fs)
 
         # Override the configuration and fs paths to use the test directory
-        cls.skill.settings_write_path = cls.test_fs
-        cls.skill.file_system.path = cls.test_fs
-        cls.skill._init_settings()
-        cls.skill.initialize()
+        # cls.skill.settings_write_path = cls.test_fs
+        # cls.skill.file_system.path = cls.test_fs
+        # cls.skill._init_settings()
+        # cls.skill.initialize()
 
         # Override speak and speak_dialog to test passed arguments
         cls.skill.speak = Mock()

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -28,51 +28,15 @@
 
 import unittest
 
-from os import mkdir, environ
-from os.path import dirname, join, exists
 from mock import Mock
-from ovos_utils.messagebus import FakeBus
 from ovos_bus_client import Message
 from lingua_franca import load_language
-from mycroft.skills.skill_loader import SkillLoader
+from neon_minerva.tests.skill_unit_test_base import SkillTestCase
 
 from skill_fallback_llm import LLM
 
 
-class TestSkill(unittest.TestCase):
-    test_fs = join(dirname(__file__), "skill_fs")
-    data_dir = join(test_fs, "data")
-    conf_dir = join(test_fs, "config")
-    environ["XDG_DATA_HOME"] = data_dir
-    environ["XDG_CONFIG_HOME"] = conf_dir
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        bus = FakeBus()
-        bus.run_in_thread()
-        skill_loader = SkillLoader(bus, dirname(dirname(__file__)))
-        skill_loader.load()
-        cls.skill = skill_loader.instance
-
-        # Define a directory to use for testing
-        # cls.test_fs = join(dirname(__file__), "skill_fs")
-        # if not exists(cls.test_fs):
-        #     mkdir(cls.test_fs)
-
-        # Override the configuration and fs paths to use the test directory
-        # cls.skill.settings_write_path = cls.test_fs
-        # cls.skill.file_system.path = cls.test_fs
-        # cls.skill._init_settings()
-        # cls.skill.initialize()
-
-        # Override speak and speak_dialog to test passed arguments
-        cls.skill.speak = Mock()
-        cls.skill.speak_dialog = Mock()
-
-    def setUp(self):
-        self.skill.speak.reset_mock()
-        self.skill.speak_dialog.reset_mock()
-
+class TestSkill(SkillTestCase):
     def test_handle_enable_fallback(self):
         self.skill.handle_enable_fallback(None)
         self.skill.speak_dialog.assert_called_once_with("fallback_enabled")


### PR DESCRIPTION
# Description
Refactor to extend FallbackSkill directly
Includes `send_email` method copied from `NeonSkill` class

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Related to https://github.com/NeonGeckoCom/NeonCore/pull/600
Base class deprecation noted in https://github.com/NeonGeckoCom/neon-utils/pull/496