### PR TITLE
Extend FallbackSkill from ovos-workshop and use Hana endpoints

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -49,12 +49,12 @@ class LLM(Enum):
 
 
 class LLMSkill(FallbackSkill):
-    chat_history = dict()
-    _default_user = "local"
-    _default_llm = LLM.FASTCHAT
-    chatting = dict()
-
-    def initialize(self):
+    def __init__(self, *args, **kwargs):
+        FallbackSkill.__init__(self, *args, **kwargs)
+        self.chat_history = dict()
+        self._default_user = "local"
+        self._default_llm = LLM.FASTCHAT
+        self.chatting = dict()
         self.register_entity_file("llm.entity")
 
     @classproperty
@@ -93,6 +93,7 @@ class LLMSkill(FallbackSkill):
                 return
             self.speak(answer)
 
+        # TODO: Speak filler?
         Thread(target=_threaded_get_response, args=(utterance, user), daemon=True).start()
         return True
 

--- a/__init__.py
+++ b/__init__.py
@@ -50,7 +50,7 @@ class LLM(Enum):
 
 class LLMSkill(FallbackSkill):
     def __init__(self, *args, **kwargs):
-        FallbackSkill.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.chat_history = dict()
         self._default_user = "local"
         self._default_llm = LLM.FASTCHAT

--- a/__init__.py
+++ b/__init__.py
@@ -77,12 +77,11 @@ class LLMSkill(FallbackSkill):
     def fallback_enabled(self):
         return self.settings.get("fallback_enabled", False)
 
-    @property
-    def priority(self):
-        return 85 if self.fallback_enabled else 101
-
     @fallback_handler(85)
     def fallback_llm(self, message):
+        if not self.fallback_enabled:
+            LOG.info("LLM Fallback Disabled")
+            return False
         utterance = message.data['utterance']
         LOG.info(f"Getting LLM response to: {utterance}")
         user = get_message_user(message) or self._default_user

--- a/__init__.py
+++ b/__init__.py
@@ -84,6 +84,7 @@ class LLMSkill(FallbackSkill):
     @fallback_handler(85)
     def fallback_llm(self, message):
         utterance = message.data['utterance']
+        LOG.info(f"Getting LLM response to: {utterance}")
         user = get_message_user(message) or self._default_user
         answer = self._get_llm_response(utterance, user, self._default_llm)
         if not answer:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 neon-utils~=1.4
 ovos-utils~=0.0, >=0.0.28
-ovos_workshop~=0.0.11
+ovos_workshop~=0.0.11,>=0.0.16a2
 neon_mq_connector~=0.7

--- a/skill.json
+++ b/skill.json
@@ -20,7 +20,7 @@
             "neon-utils~=1.4",
             "neon_mq_connector~=0.7",
             "ovos-utils~=0.0, >=0.0.28",
-            "ovos_workshop~=0.0.11"
+            "ovos_workshop~=0.0.11,>=0.0.16a2"
         ],
         "system": {},
         "skill": []

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -92,8 +92,7 @@ class TestSkill(SkillTestCase):
         self.assertEqual(self.skill.chatting["test_user"][1].value,
                          LLM.GPT.value)
         self.skill.speak_dialog.assert_called_once_with(
-            "start_chat", {"llm": "Chat GPT", "timeout": "five minutes"},
-            private=True)
+            "start_chat", {"llm": "Chat GPT", "timeout": "five minutes"})
 
     def test_handle_email_chat_history(self):
         real_send_email = self.skill._send_email
@@ -107,22 +106,19 @@ class TestSkill(SkillTestCase):
                                         "user_profiles": [default_profile]})
         # No Chat History
         self.skill.handle_email_chat_history(test_message)
-        self.skill.speak_dialog.assert_called_once_with("no_chat_history",
-                                                        private=True)
+        self.skill.speak_dialog.assert_called_once_with("no_chat_history")
 
         # No Email Address
         self.skill.chat_history['test_user'] = [("user", "hey"), ("llm", "hi")]
         self.skill.handle_email_chat_history(test_message)
-        self.skill.speak_dialog.assert_called_with("no_email_address",
-                                                   private=True)
+        self.skill.speak_dialog.assert_called_with("no_email_address")
 
         # Valid Request
         test_message.context['user_profiles'][0]['user']['email'] = \
             "test@neon.ai"
         self.skill.handle_email_chat_history(test_message)
         self.skill.speak_dialog.assert_called_with("sending_chat_history",
-                                                   {"email": "test@neon.ai"},
-                                                   private=True)
+                                                   {"email": "test@neon.ai"})
         self.skill._send_email.assert_called_once_with("test_user",
                                                        "test@neon.ai")
 


### PR DESCRIPTION
# Description
Updates skill to extend FallbackSkill to support future v2 implementations
Refactor to use HANA endpoint instead of MQ for LLM responses
Thread response handling to prevent fallback service timeouts
Remove deprecated method args

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->